### PR TITLE
fix: repair IO wrapper import consolidation bugs

### DIFF
--- a/src/deeploop/artifacts/artifact_packager.py
+++ b/src/deeploop/artifacts/artifact_packager.py
@@ -15,11 +15,7 @@ from deeploop.artifacts.release_automation import (
     materialize_release_candidate_review,
 )
 from deeploop.core.shared import is_relative_to as _is_relative_to
-from deeploop.core.structured_io import (
-    load_json_object as _load_json,
-    load_jsonl_objects as _load_jsonl,
-    load_yaml_mapping as _load_yaml,
-)
+from deeploop.core.structured_io import load_json_object, load_jsonl_objects, load_yaml_mapping
 from deeploop.mission.mission_acceptance import evaluate_mission_acceptance
 from deeploop.core.paths import REPO_ROOT, RUNS_DIR, WORKSPACE_ROOT, resolve_workspace_path
 
@@ -484,7 +480,7 @@ def _extract_text_bullets(path: Path, *, limit: int = 4) -> list[str]:
 
 
 def load_package_contract(path: Path = PACKAGE_CONTRACT_PATH) -> dict[str, Any]:
-    return _load_yaml(path)
+    return load_yaml_mapping(path)
 
 
 def validate_package_manifest(package: dict[str, Any], schema_path: Path = PACKAGE_SCHEMA_PATH) -> list[str]:
@@ -494,7 +490,7 @@ def validate_package_manifest(package: dict[str, Any], schema_path: Path = PACKA
         return []
 
     try:
-        jsonschema.validate(package, _load_json(schema_path))
+        jsonschema.validate(package, load_json_object(schema_path))
     except Exception as exc:  # pragma: no cover - jsonschema type depends on install
         return [str(exc)]
     return []
@@ -528,7 +524,7 @@ def _resolve_manifest_paths(search_roots: list[Path], mission_id: str, patterns:
                 if not path.is_file():
                     continue
                 try:
-                    manifest = _load_json(path)
+                    manifest = load_json_object(path)
                 except Exception:
                     continue
                 if manifest.get("mission_id") == mission_id:
@@ -587,7 +583,7 @@ def _bundle_related_paths(manifest_path: Path, manifest: dict[str, Any], contrac
     ]
     for critique_json in critique_json_candidates:
         try:
-            report = _load_json(critique_json)
+            report = load_json_object(critique_json)
         except Exception:
             continue
         artifacts_payload = report.get("artifacts", {})
@@ -618,7 +614,7 @@ def _collect_global_reports(
                 metadata: dict[str, Any] = {}
                 if path.suffix.lower() == ".json":
                     try:
-                        payload = _load_json(path)
+                        payload = load_json_object(path)
                     except Exception:
                         continue
                     mission_id = payload.get("mission_id")
@@ -820,7 +816,7 @@ def _metric_fragments(path: Path, *, limit: int = 3) -> list[str]:
     if path.suffix.lower() != ".json":
         return []
     try:
-        payload = _load_json(path)
+        payload = load_json_object(path)
     except Exception:
         return []
     if not isinstance(payload, dict):
@@ -894,12 +890,12 @@ def package_mission_artifacts(
 ) -> dict[str, Any]:
     mission_state_path = mission_state_path.expanduser().resolve()
     contract_path = contract_path.expanduser().resolve()
-    mission_state = _load_json(mission_state_path)
+    mission_state = load_json_object(mission_state_path)
     mission_root = mission_state_path.parent
     mission_id = str(mission_state["mission_id"])
     target_repo = _safe_resolve(mission_state["target_repo"])
     contract = load_package_contract(contract_path)
-    evidence_policy = _load_yaml(EVIDENCE_POLICY_PATH)
+    evidence_policy = load_yaml_mapping(EVIDENCE_POLICY_PATH)
 
     resolved_output_root = _safe_resolve(output_root or contract.get("output_root", RUNS_DIR / "packages"))
     _validate_output_root(resolved_output_root, mission_state)
@@ -1090,12 +1086,12 @@ def package_mission_artifacts(
                 target_repo=target_repo,
             )
             if memory_path.exists() and memory_path.is_file():
-                for entry in _load_jsonl(memory_path):
+                for entry in load_jsonl_objects(memory_path, missing_ok=True):
                     if isinstance(entry, dict):
                         register_outputs_from_mapping(entry, declared_by="agent_driver.memory", source_path=memory_path, phase=str(entry.get("phase") or "") or None)
     experiments_path = mission_root / "mission_experiments.jsonl"
     if experiments_path.exists():
-        for entry in _load_jsonl(experiments_path):
+        for entry in load_jsonl_objects(experiments_path, missing_ok=True):
             if isinstance(entry, dict):
                 register_outputs_from_mapping(entry, declared_by="mission_experiments", source_path=experiments_path, phase=str(entry.get("phase") or "") or None)
 
@@ -1112,7 +1108,7 @@ def package_mission_artifacts(
 
     run_bundles: list[dict[str, Any]] = []
     for manifest_path in manifest_paths:
-        manifest = _load_json(manifest_path)
+        manifest = load_json_object(manifest_path)
         manifest_artifact_id = register_artifact(
             manifest_path,
             category="manifests",
@@ -1143,7 +1139,7 @@ def package_mission_artifacts(
             critique_metadata: dict[str, Any] = {}
             if critique_path.suffix.lower() == ".json":
                 try:
-                    report = _load_json(critique_path)
+                    report = load_json_object(critique_path)
                 except Exception:
                     report = {}
                 if isinstance(report.get("promotion_guidance"), dict):
@@ -1188,7 +1184,7 @@ def package_mission_artifacts(
     ledger_entries: list[dict[str, Any]] = []
     if ledger_path.exists():
         ledger_artifact_id = register_artifact(ledger_path, category="ledgers")
-        ledger_entries = _load_jsonl(ledger_path)
+        ledger_entries = load_jsonl_objects(ledger_path, missing_ok=True)
         for entry in ledger_entries:
             related_paths = entry.get("related_paths", [])
             for raw_path in related_paths:
@@ -1462,7 +1458,7 @@ def package_mission_artifacts(
         )
     mission_memory_path = mission_root / "mission_memory.json"
     if mission_memory_path.exists():
-        mission_memory = _load_json(mission_memory_path)
+        mission_memory = load_json_object(mission_memory_path)
         retrieved_research = (
             mission_memory.get("retrieved_research_context")
             if isinstance(mission_memory.get("retrieved_research_context"), dict)

--- a/src/deeploop/artifacts/real_runtime_validation.py
+++ b/src/deeploop/artifacts/real_runtime_validation.py
@@ -14,15 +14,7 @@ from deeploop.artifacts.release_automation import GATE_2_RUNTIME_CONTRACT_PATH, 
 from deeploop.cli.analyze import _build_analyze_prompt, _render_analyze_result
 from deeploop.core.ledger import append_jsonl, make_ledger_entry, now_utc
 from deeploop.core.paths import REPO_ROOT, resolve_workspace_path
-from deeploop.core.structured_io import (
-    json_safe_value,
-    load_json_object,
-    load_yaml_mapping,
-    write_json_object,
-    write_markdown,
-    write_text,
-    write_yaml_mapping,
-)
+from deeploop.core.structured_io import load_json_object, load_yaml_mapping, write_json_object
 from deeploop.mission.mission_state import load_mission_state, write_mission_state
 from deeploop.core.shared import dedupe_strings as _dedupe_strings, slugify as _slugify
 from deeploop.mission.orchestrator import initialize_mission

--- a/src/deeploop/artifacts/release_automation.py
+++ b/src/deeploop/artifacts/release_automation.py
@@ -6,10 +6,7 @@ from typing import Any
 
 from deeploop.core.ledger import now_utc
 from deeploop.core.paths import REPO_ROOT
-from deeploop.core.structured_io import (
-    load_json_object as _load_json,
-    load_yaml_mapping as _load_yaml,
-)
+from deeploop.core.structured_io import load_json_object, load_yaml_mapping
 
 RELEASE_POLICY_PATH = REPO_ROOT / "configs" / "runtime" / "release-candidate-policy.yaml"
 EVIDENCE_POLICY_PATH = REPO_ROOT / "configs" / "autonomy" / "evidence-policy.yaml"
@@ -26,15 +23,15 @@ CLAIM_ORDER = {
 
 
 def load_release_candidate_policy(path: Path = RELEASE_POLICY_PATH) -> dict[str, Any]:
-    return _load_yaml(path)
+    return load_yaml_mapping(path)
 
 
 def load_evidence_policy(path: Path = EVIDENCE_POLICY_PATH) -> dict[str, Any]:
-    return _load_yaml(path)
+    return load_yaml_mapping(path)
 
 
 def load_gate_2_runtime_contract(path: Path = GATE_2_RUNTIME_CONTRACT_PATH) -> dict[str, Any]:
-    return _load_yaml(path)
+    return load_yaml_mapping(path)
 
 
 def load_release_candidate_reviews(path: Path | None) -> dict[str, Any]:
@@ -42,9 +39,9 @@ def load_release_candidate_reviews(path: Path | None) -> dict[str, Any]:
         return {"reviews": []}
     resolved = path.expanduser().resolve()
     if resolved.suffix.lower() in {".yaml", ".yml"}:
-        payload = _load_yaml(resolved)
+        payload = load_yaml_mapping(resolved)
     else:
-        payload = _load_json(resolved)
+        payload = load_json_object(resolved)
     if not isinstance(payload, dict):
         raise ValueError(f"Release reviews must be a mapping: {resolved}")
     if "reviews" not in payload and isinstance(payload.get("approvals"), list):
@@ -67,7 +64,7 @@ def validate_release_candidate_review(
         return []
 
     try:
-        jsonschema.validate(review, _load_json(schema_path))
+        jsonschema.validate(review, load_json_object(schema_path))
     except Exception as exc:  # pragma: no cover
         return [str(exc)]
     return []

--- a/src/deeploop/autonomy/operator_inbox.py
+++ b/src/deeploop/autonomy/operator_inbox.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping
 from deeploop.core.ledger import append_jsonl, now_utc
 from deeploop.core.paths import REPO_ROOT
 from deeploop.core.shared import resolved_contract_path
-from deeploop.core.structured_io import schema_errors
+from deeploop.core.structured_io import load_json_object, load_jsonl_objects, schema_errors, write_json_object
 
 DEFAULT_OPERATOR_REQUEST_LOG_FILE = "mission_operator_requests.jsonl"
 DEFAULT_CURRENT_OPERATOR_REQUEST_FILE = "current_operator_request.json"

--- a/src/deeploop/mission/_runtime_persistence.py
+++ b/src/deeploop/mission/_runtime_persistence.py
@@ -90,7 +90,7 @@ def _record_history(runtime_root: Path, payload: dict[str, Any]) -> None:
     append_jsonl(_runtime_history_path(runtime_root), payload)
 
 def _runtime_summary(runtime_state: dict[str, Any], *, mission_state: dict[str, Any]) -> dict[str, Any]:
-    history = load_jsonl_objects(_runtime_history_path(Path(runtime_state["runtime_root"], missing_ok=True)))
+    history = load_jsonl_objects(_runtime_history_path(Path(runtime_state["runtime_root"])), missing_ok=True)
     outer_loop = mission_state.get("outer_loop") if isinstance(mission_state.get("outer_loop"), dict) else {}
     memory_path = (
         Path(outer_loop["mission_memory_path"]).expanduser().resolve()

--- a/src/deeploop/platform/contracts.py
+++ b/src/deeploop/platform/contracts.py
@@ -6,10 +6,7 @@ from typing import Any, Mapping
 
 from deeploop.core.ledger import now_utc
 from deeploop.core.paths import REPO_ROOT
-from deeploop.core.structured_io import (
-    load_json_object as _load_json,
-    load_yaml_mapping as _load_yaml,
-)
+from deeploop.core.structured_io import load_json_object, load_yaml_mapping, write_json_object
 
 DEFAULT_PLATFORM_EXPANSION_CONTRACT_PATH = REPO_ROOT / "configs" / "platform" / "expansion.yaml"
 
@@ -27,7 +24,7 @@ def _resolve_templates(value: object, context: dict[str, str]) -> object:
     return value
 
 def load_platform_expansion_contract(path: Path = DEFAULT_PLATFORM_EXPANSION_CONTRACT_PATH) -> dict[str, object]:
-    return _load_yaml(path)
+    return load_yaml_mapping(path)
 
 def _seed_surface_output(path: Path, *, surface_id: str, mission_id: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -73,7 +70,7 @@ def _surface_paths(surface: Mapping[str, Any], *, suffix: str) -> list[Path]:
 def _load_optional_json(path: Path | None) -> dict[str, Any]:
     if path is None or not path.exists():
         return {}
-    loaded = _load_json(path)
+    loaded = load_json_object(path)
     return loaded if isinstance(loaded, dict) else {}
 
 def _relative_to_mission(path: Path, mission_root: Path) -> str:

--- a/src/deeploop/research/sanity_gates.py
+++ b/src/deeploop/research/sanity_gates.py
@@ -9,11 +9,7 @@ from deeploop.core.config_paths import infer_repo_root_from_configs as _infer_re
 from deeploop.core.shared import get_dotted as _get_field
 from deeploop.core.ledger import append_jsonl, make_ledger_entry, now_utc
 from deeploop.core.paths import REPO_ROOT, RUNS_DIR
-from deeploop.core.structured_io import (
-    load_json_object as _load_json,
-    load_structured_mapping as _load_structured,
-    load_yaml_mapping as _load_yaml,
-)
+from deeploop.core.structured_io import load_json_object, load_yaml_mapping
 from deeploop.research.confound_guard import DEFAULT_CONTRACT_PATH as DEFAULT_CONFOUND_CONTRACT_PATH, evaluate_confound_guard
 
 DEFAULT_CONTRACT_PATH = REPO_ROOT / "configs" / "autonomy" / "research-sanity-gates.yaml"
@@ -191,7 +187,7 @@ def _validate_report(report: dict) -> None:
         import jsonschema
     except ImportError:
         return
-    schema = _load_json(REPORT_SCHEMA_PATH)
+    schema = load_json_object(REPORT_SCHEMA_PATH)
     jsonschema.validate(report, schema)
 
 
@@ -219,7 +215,7 @@ def evaluate_research_sanity(
     config = None
     config_kind = "unknown"
     repo_root = repo_root or _infer_repo_root(config_path)
-    contract = _load_yaml(contract_path)
+    contract = load_yaml_mapping(contract_path)
 
     if not config_path.exists():
         checks.append(
@@ -293,9 +289,9 @@ def evaluate_research_sanity(
             parse_as = reference.get("parse_as")
             try:
                 if parse_as == "json":
-                    parsed_content = _load_json(resolved_path)
+                    parsed_content = load_json_object(resolved_path)
                 elif parse_as == "yaml":
-                    parsed_content = _load_yaml(resolved_path)
+                    parsed_content = load_yaml_mapping(resolved_path)
                 checks.append(
                     _new_check(
                         f"reference:{field}",
@@ -328,7 +324,7 @@ def evaluate_research_sanity(
         if dataset_probe_error is not None:
             checks.append(dataset_probe_error)
         elif dataset_probe is not None:
-            promotion_manifest = _load_json(dataset_probe["promotion_manifest_path"])
+            promotion_manifest = load_json_object(dataset_probe["promotion_manifest_path"])
             selection = dataset_probe["selection"]
             selected_entries = _select_promotion_entries(
                 promotion_manifest,
@@ -490,9 +486,9 @@ def evaluate_research_sanity(
             else:
                 details["contract_exists"] = True
                 if contract_file.suffix.lower() in {".yaml", ".yml"}:
-                    details["contract"] = _load_yaml(contract_file)
+                    details["contract"] = load_yaml_mapping(contract_file)
                 elif contract_file.suffix.lower() == ".json":
-                    details["contract"] = _load_json(contract_file)
+                    details["contract"] = load_json_object(contract_file)
 
         if evaluation_missing:
             checks.append(
@@ -654,7 +650,7 @@ def evaluate_research_sanity(
         },
     }
     if mission_state_path is not None and mission_state_path.exists():
-        mission_state = _load_json(mission_state_path)
+        mission_state = load_json_object(mission_state_path)
         report["mission_id"] = mission_state.get("mission_id")
 
     _validate_report(report)

--- a/src/deeploop/research/statistical_rigor.py
+++ b/src/deeploop/research/statistical_rigor.py
@@ -8,12 +8,7 @@ from typing import Any
 from deeploop.core.ledger import append_jsonl, make_ledger_entry, now_utc
 from deeploop.core.shared import get_dotted as _get_nested
 from deeploop.core.paths import MISSIONS_DIR, RUNS_DIR
-from deeploop.core.structured_io import (
-    load_json_object as _load_json,
-    load_jsonl as _load_jsonl,
-    load_structured_mapping as _load_structured_file,
-    load_yaml_mapping as _load_yaml,
-)
+from deeploop.core.structured_io import load_json_object, load_jsonl_objects, load_yaml_mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_CONTRACT_PATH = REPO_ROOT / "configs" / "autonomy" / "statistical-rigor.yaml"
@@ -583,7 +578,7 @@ def evaluate_statistical_rigor(
     output_root: Path | None = None,
     artifact_name: str | None = None,
 ) -> dict[str, Any]:
-    contract = _load_yaml(contract_path)
+    contract = load_yaml_mapping(contract_path)
     uncertainty_cfg = contract.get("uncertainty", {})
     bundle = _resolve_target_bundle(target_path, contract)
     manifest = bundle["manifest"]
@@ -594,7 +589,7 @@ def evaluate_statistical_rigor(
             if inferred.exists():
                 mission_state_path = inferred
 
-    predictions = _load_jsonl(bundle["predictions_path"]) if bundle["predictions_path"] else []
+    predictions = load_jsonl_objects(bundle["predictions_path"]) if bundle["predictions_path"] else []
     predictions_primary = _summary_from_predictions(predictions, source="predictions.jsonl", uncertainty_cfg=uncertainty_cfg)
     direct_primary = predictions_primary or _summary_from_metrics(
         bundle["metrics"],
@@ -698,7 +693,7 @@ def evaluate_statistical_rigor(
         _write_markdown_report(co_located_md_path, report)
 
     if mission_state_path is not None and mission_state_path.exists():
-        mission_state = _load_json(mission_state_path)
+        mission_state = load_json_object(mission_state_path)
         related_paths = [path for path in [report_json_path, report_markdown_path, co_located_json_path, co_located_md_path, bundle["manifest_path"]] if path is not None]
         append_jsonl(
             mission_state_path.parent / "ledger.jsonl",

--- a/src/deeploop/runtime/adaptation_training_runtime.py
+++ b/src/deeploop/runtime/adaptation_training_runtime.py
@@ -15,6 +15,7 @@ from deeploop.autonomy.gate_taxonomy import build_gate_event, load_gate_policy
 from deeploop.core.ledger import now_utc
 from deeploop.core.paths import REPO_ROOT
 from deeploop.core.shared import build_command as _build_command
+from deeploop.core.structured_io import load_json_object, write_json_object
 from deeploop.runtime.metric_ratchets import (
     MetricRatchetConfig,
     build_metric_ratchet_decision,

--- a/src/deeploop/runtime/recursive_agent_runtime.py
+++ b/src/deeploop/runtime/recursive_agent_runtime.py
@@ -1329,7 +1329,7 @@ def run_recursive_agent_loop(config_path: Path) -> dict[str, Any]:
         summary_markdown_path = iteration_root / "summary.md"
 
         recent_ledger = _recent_entries(load_jsonl_objects(ledger_path, missing_ok=True), recent_ledger_limit)
-        recent_memory = _recent_entries(load_jsonl_objects(_memory_path(runtime_root, missing_ok=True)), recent_memory_limit)
+        recent_memory = _recent_entries(load_jsonl_objects(_memory_path(runtime_root), missing_ok=True), recent_memory_limit)
         outer_loop = mission_state.get("outer_loop", {}) if isinstance(mission_state.get("outer_loop"), dict) else {}
         decision_log_path = Path(outer_loop["decision_log_path"]) if isinstance(outer_loop.get("decision_log_path"), str) else None
         branch_log_path = Path(outer_loop["branch_log_path"]) if isinstance(outer_loop.get("branch_log_path"), str) else None

--- a/src/deeploop/runtime/runtime_recovery.py
+++ b/src/deeploop/runtime/runtime_recovery.py
@@ -12,6 +12,7 @@ import yaml
 from deeploop.core.ledger import append_jsonl, make_ledger_entry
 from deeploop.core.paths import REPO_ROOT
 from deeploop.runtime.stage_kernels import StageAdapter, load_stage_adapter, run_stage_from_config
+from deeploop.core.structured_io import write_json_object
 
 logger = logging.getLogger(__name__)
 

--- a/src/deeploop/runtime/self_healing_runtime.py
+++ b/src/deeploop/runtime/self_healing_runtime.py
@@ -17,6 +17,7 @@ from deeploop.core.paths import REPO_ROOT as DEEPLOOP_REPO_ROOT
 from deeploop.core.shared import build_command as _build_command, is_relative_to as _is_relative_to
 from deeploop.research.sanity_gates import evaluate_research_sanity, extract_proposal_config_path
 from deeploop.research.self_correction import assess_manifest_for_self_correction
+from deeploop.core.structured_io import load_json_object, write_json_object
 
 DEFAULT_POLICY_PATH = DEEPLOOP_REPO_ROOT / "configs" / "runtime" / "self-healing-runtime.yaml"
 RUN_MANIFEST_SCHEMA_PATH = DEEPLOOP_REPO_ROOT / "schemas" / "run-manifest.schema.json"


### PR DESCRIPTION
## Summary
Fixes 3 classes of bugs introduced by the Phase 2 automated IO wrapper consolidation script.

## Bugs Fixed
1. **misplaced `missing_ok=True`**: placed inside `_memory_path()` instead of `load_jsonl_objects()` — caused TypeError in all recursive agent runtime tests
2. **Missing imports**: 11 files lost their `structured_io` imports when local wrappers were removed (`write_json_object`, `load_json_object`, `load_jsonl_objects`, `load_yaml_mapping`)
3. **Corrupted import lines**: import lines corrupted when appended inside multi-line import blocks

## Test Results
- Unit tests: 78 tests, 2 errors (Docker validation — pre-existing)
- Integration tests: 41 tests, 8 errors (`_runtime_artifacts` fixtures — pre-existing, never in git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)