### PR TITLE
fix: update test paths and docs for moved/deleted config files

### DIFF
--- a/docs/reference/provider-selection.md
+++ b/docs/reference/provider-selection.md
@@ -48,7 +48,7 @@ the first-class mission/runtime selection set:
 - local backend defaults and ladder input: `configs/runtime/backend-policy.yaml`
 - recursive-loop policy surface: `configs/runtime/recursive-agent-runtime.yaml`
 - recursive-loop example with selection block:
-  `configs/runtime/recursive-agent-runtime-provider.example.yaml`
+  `examples/recursive-agent-runtime-provider.example.yaml`
 - role/env map: `configs/sandbox/agent-launch-policy.yaml`
 - manifest recording surface: `configs/manifests/run-manifest-template.json`
 
@@ -186,7 +186,7 @@ the local fallback ladder between `local-transformers` and `vllm`. It does not
 by itself choose which provider a mission should use.
 
 ### `configs/runtime/recursive-agent-runtime.yaml`
-### `configs/runtime/recursive-agent-runtime-provider.example.yaml`
+### `examples/recursive-agent-runtime-provider.example.yaml`
 
 Recursive-agent loop configs may now carry a `provider_selection` block to
 express mission/runtime intent separately from machine setup.
@@ -198,7 +198,7 @@ adapter. The `provider_selection` block remains the canonical selection contract
 for that loop.
 
 The shipped example at
-`configs/runtime/recursive-agent-runtime-provider.example.yaml` pins the
+`examples/recursive-agent-runtime-provider.example.yaml` pins the
 `deepseek-chat-control-plane` profile so the concrete control-plane lane is
 explicit on this runtime surface.
 

--- a/tests/_proof_fixtures/plain_folder/translation-budget-ladder/translation-long-run-baseline-queue.yaml
+++ b/tests/_proof_fixtures/plain_folder/translation-budget-ladder/translation-long-run-baseline-queue.yaml
@@ -1,0 +1,52 @@
+version: 1
+queue_name: translation-long-run-baselines
+mission_state: workspace://runs/deeploop/missions/translation-long-run-mission/mission_state.json
+runtime_policy: workspace://repos/deeploop/configs/runtime/self-healing-runtime.yaml
+rerun_existing: false
+max_jobs: 3
+entries:
+  - id: qwen35-2b-base-phase1
+    env_name: llm
+    repo: workspace://repos/translation-pilot
+    stage_id: baseline-evaluation
+    adapter: translation_pilot.runtime_adapter:build_stage_adapter
+    pythonpath:
+      - workspace://repos/translation-pilot/src
+    command:
+      - python
+      - scripts/eval/run_baseline.py
+      - --config
+      - configs/eval/qwen35-2b-base-phase1.yaml
+    repair:
+      reroute_env_name: llm
+    expected_manifest: workspace://runs/translation-pilot/qwen35-2b-base-phase1/run_manifest.json
+  - id: qwen35-4b-phase1
+    env_name: llm
+    repo: workspace://repos/translation-pilot
+    stage_id: baseline-evaluation
+    adapter: translation_pilot.runtime_adapter:build_stage_adapter
+    pythonpath:
+      - workspace://repos/translation-pilot/src
+    command:
+      - python
+      - scripts/eval/run_baseline.py
+      - --config
+      - configs/eval/qwen35-4b-phase1.yaml
+    repair:
+      reroute_env_name: llm
+    expected_manifest: workspace://runs/translation-pilot/qwen35-4b-phase1/run_manifest.json
+  - id: gemma4-e4b-it-phase1
+    env_name: llm
+    repo: workspace://repos/translation-pilot
+    stage_id: baseline-evaluation
+    adapter: translation_pilot.runtime_adapter:build_stage_adapter
+    pythonpath:
+      - workspace://repos/translation-pilot/src
+    command:
+      - python
+      - scripts/eval/run_baseline.py
+      - --config
+      - configs/eval/gemma4-e4b-it-phase1.yaml
+    repair:
+      reroute_env_name: llm
+    expected_manifest: workspace://runs/translation-pilot/gemma4-e4b-it-phase1/run_manifest.json

--- a/tests/test_repo_contract.py
+++ b/tests/test_repo_contract.py
@@ -72,9 +72,7 @@ class RepoContractTests(unittest.TestCase):
 
     def test_release_governance_surfaces_classify_boundaries(self) -> None:
         governance_doc = REPO_ROOT / "docs" / "release" / "autonomy-governance.md"
-        governance_cfg = REPO_ROOT / "configs" / "autonomy" / "operator-boundaries.yaml"
         self.assertTrue(governance_doc.exists(), f"missing governance doc: {governance_doc}")
-        self.assertTrue(governance_cfg.exists(), f"missing governance config: {governance_cfg}")
         governance_text = governance_doc.read_text(encoding="utf-8").lower()
         self.assertIn("hard-gate", governance_text)
         self.assertIn("authority-boundary", governance_text)
@@ -85,14 +83,6 @@ class RepoContractTests(unittest.TestCase):
         self.assertIn("provenance-review", governance_text)
         self.assertIn("licensing-review", governance_text)
         self.assertIn("release-operator", governance_text)
-        config = yaml.safe_load(governance_cfg.read_text(encoding="utf-8"))
-        self.assertIn("operator_request_classes", config)
-        self.assertIn("hard-gate", config["operator_request_classes"])
-        self.assertIn("authority-boundary", config["operator_request_classes"])
-        self.assertIn("operator-review", config["operator_request_classes"])
-        self.assertIn("unrecoverable-failure", config["operator_request_classes"])
-        self.assertIn("release_governance", config)
-        self.assertIn("required_reviews", config["release_governance"])
 
     def test_policy_placement_doc_mentions_taxonomy_and_antipattern(self) -> None:
         policy_text = (REPO_ROOT / "docs" / "design" / "policy-placement.md").read_text(encoding="utf-8").lower()
@@ -405,7 +395,7 @@ class RepoContractTests(unittest.TestCase):
         self.assertIn("machine-level provider setup", selection_text)
         self.assertIn("configs/runtime/provider-selection-registry.yaml", selection_text)
         self.assertIn("configs/runtime/backend-policy.yaml", selection_text)
-        self.assertIn("configs/runtime/recursive-agent-runtime-provider.example.yaml", selection_text)
+        self.assertIn("examples/recursive-agent-runtime-provider.example.yaml", selection_text)
         self.assertIn("configs/runtime/gate-2-runtime-lanes.yaml", selection_text)
         self.assertIn("configs/sandbox/agent-launch-policy.yaml", selection_text)
         self.assertIn("configs/manifests/run-manifest-template.json", selection_text)
@@ -489,7 +479,7 @@ class RepoContractTests(unittest.TestCase):
     def test_gate_2_runtime_lane_contract_surfaces_exist(self) -> None:
         gate_doc = REPO_ROOT / "docs" / "release" / "release-maintenance.md"
         gate_config = REPO_ROOT / "configs" / "runtime" / "gate-2-runtime-lanes.yaml"
-        recursive_example = REPO_ROOT / "configs" / "runtime" / "recursive-agent-runtime-provider.example.yaml"
+        recursive_example = REPO_ROOT / "examples" / "recursive-agent-runtime-provider.example.yaml"
         self.assertTrue(gate_doc.exists(), f"missing release maintenance doc: {gate_doc}")
         self.assertTrue(gate_config.exists(), f"missing Gate 2 lane config: {gate_config}")
         self.assertTrue(recursive_example.exists(), f"missing recursive runtime example: {recursive_example}")
@@ -562,7 +552,7 @@ class RepoContractTests(unittest.TestCase):
         self.assertIn("--until-complete", completed.stdout)
 
     def test_autoexecutor_queue_config_exists(self) -> None:
-        queue_path = REPO_ROOT / "configs" / "runtime" / "translation-long-run-baseline-queue.yaml"
+        queue_path = REPO_ROOT / "examples" / "translation-budget-ladder" / "translation-long-run-baseline-queue.yaml"
         self.assertTrue(queue_path.exists(), f"missing public example queue: {queue_path}")
 
     def test_tiny_autopilot_proof_assets_exist(self) -> None:


### PR DESCRIPTION
## Summary
Updates tests, docs, and fixtures to match the moved/deleted config files from v0.3.0.

## Changes
- Remove `operator-boundaries.yaml` references from test (file was deleted — dead config, 0 Python references)
- Update `provider-selection.md`: `configs/runtime/` → `examples/` for example config
- Update `translation-long-run-baseline-queue.yaml` test path (moved from configs/runtime/ to examples/)
- Sync queue config to proof fixture directory

## Test Results
- 24/24 repo_contract tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)