### PR TITLE
fix: handle missing files after IO wrapper consolidation

### DIFF
--- a/src/deeploop/autonomy/operator_inbox.py
+++ b/src/deeploop/autonomy/operator_inbox.py
@@ -103,6 +103,8 @@ def clear_current_operator_request(current_path: Path) -> None:
     write_json_object(current_path, {})
 
 def load_current_operator_request(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
     loaded = load_json_object(path)
     return loaded if isinstance(loaded.get("request_id"), str) and loaded.get("request_id") else None
 

--- a/src/deeploop/project_contract.py
+++ b/src/deeploop/project_contract.py
@@ -206,7 +206,7 @@ def discover_project_contract(target_repo: Path) -> dict[str, Any]:
     repo_agents = repo_root / "AGENTS.md"
     repo_copilot = repo_root / ".github" / "copilot-instructions.md"
 
-    project_payload = load_yaml_mapping(project_path)
+    project_payload = load_yaml_mapping(project_path) if project_path.exists() else {}
     artifacts_payload = project_payload.get("artifacts") if isinstance(project_payload.get("artifacts"), dict) else {}
     docs = _normalize_paths(artifacts_payload.get("docs"), base_dir=repo_root)
     configs = _normalize_paths(artifacts_payload.get("configs"), base_dir=repo_root)
@@ -234,7 +234,7 @@ def discover_project_contract(target_repo: Path) -> dict[str, Any]:
         if path.exists()
     ]
     plain_facts_path = next((repo_root / name for name, _ in _PLAIN_PROJECT_FACT_FILES if (repo_root / name).exists()), None)
-    if not contract_root.exists() and plain_facts_path is not None:
+    if not contract_root.exists() and plain_facts_path is not None and plain_facts_path.exists():
         plain_payload = load_yaml_mapping(plain_facts_path)
         plain_project = plain_payload.get("project") if isinstance(plain_payload.get("project"), dict) else {}
         plain_artifacts_payload = plain_payload.get("artifacts") if isinstance(plain_payload.get("artifacts"), dict) else {}


### PR DESCRIPTION
## Summary
The old private `_load_json` / `_load_yaml` wrappers silently returned `{}` on missing files. The canonical `load_json_object` / `load_yaml_mapping` functions crash with `FileNotFoundError`. 

## Changes
- `operator_inbox.py`: `load_current_operator_request()` — add `.exists()` guard (called from `build_mission_snapshot`)
- `project_contract.py`: `discover_project_contract()` — add `.exists()` guard for `project.yaml` and `plain_facts_path`

## Test Results (local)
- Integration: 41/41 ✅
- Unit: 77/78 ✅ (1 docker validation — needs Docker daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)