### PR TITLE
feat: v0.4.0 — Tree search by default, Anthropic model tiers, research scripts

### DIFF
--- a/configs/runtime/model-tiers.yaml
+++ b/configs/runtime/model-tiers.yaml
@@ -13,6 +13,7 @@ tiers:
   reasoning:
     label: Expensive model for planning, architecture decisions, paper writing
     model_identifier: deepseek-reasoner
+    model_identifier_anthropic: claude-opus-4-20250514
     intended_roles:
       - planner
       - experiment-designer
@@ -28,6 +29,7 @@ tiers:
   execution:
     label: Fast/cheap model for code generation, metric parsing, monitoring
     model_identifier: deepseek-chat
+    model_identifier_anthropic: claude-sonnet-4-20250514
     intended_roles:
       - literature-scout
       - execution-operator
@@ -46,3 +48,9 @@ pricing_per_1m_tokens:
   deepseek-reasoner:
     input: 0.55
     output: 2.19
+  claude-sonnet-4-20250514:
+    input: 3.00
+    output: 15.00
+  claude-opus-4-20250514:
+    input: 15.00
+    output: 75.00

--- a/scripts/mission/run_statistical_rigor.py
+++ b/scripts/mission/run_statistical_rigor.py
@@ -1,0 +1,61 @@
+"""Mission script to run statistical-rigor evaluation.
+
+Produces durable JSON/MD analysis artifacts and integrates findings into the mission ledger.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from deeploop.research.statistical_rigor import evaluate_statistical_rigor
+
+
+def run_statistical_rigor_for_mission(
+    artifact_name: str,
+    mission_state_path: Path | str | None = None,
+    contract_path: Path | str | None = None,
+    verbose: bool = False,
+) -> dict:
+    contract = Path(contract_path) if contract_path else None
+    state_path = Path(mission_state_path) if mission_state_path else None
+    return evaluate_statistical_rigor(
+        artifact_name=artifact_name,
+        mission_state_path=state_path,
+        contract_path=contract,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run DeepLoop statistical-rigor evaluation")
+    parser.add_argument("--artifact-name", required=True)
+    parser.add_argument("--mission-state-path")
+    parser.add_argument("--contract-path")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = run_statistical_rigor_for_mission(
+        artifact_name=args.artifact_name,
+        mission_state_path=args.mission_state_path,
+        contract_path=args.contract_path,
+        verbose=args.verbose,
+    )
+    if args.json:
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for line in result.get("lines", [str(result)]):
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mission/run_utility_scorer.py
+++ b/scripts/mission/run_utility_scorer.py
@@ -1,0 +1,61 @@
+"""Mission script to run utility-scorer branch ranking.
+
+Produces durable JSON/MD scoring artifacts and integrates findings into the mission ledger.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from deeploop.research.utility_scorer import evaluate_utility_score
+
+
+def run_utility_scorer_for_mission(
+    artifact_name: str,
+    mission_state_path: Path | str | None = None,
+    contract_path: Path | str | None = None,
+    verbose: bool = False,
+) -> dict:
+    contract = Path(contract_path) if contract_path else None
+    state_path = Path(mission_state_path) if mission_state_path else None
+    return evaluate_utility_score(
+        artifact_name=artifact_name,
+        mission_state_path=state_path,
+        contract_path=contract,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run DeepLoop utility-scorer branch ranking")
+    parser.add_argument("--artifact-name", required=True)
+    parser.add_argument("--mission-state-path")
+    parser.add_argument("--contract-path")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = run_utility_scorer_for_mission(
+        artifact_name=args.artifact_name,
+        mission_state_path=args.mission_state_path,
+        contract_path=args.contract_path,
+        verbose=args.verbose,
+    )
+    if args.json:
+        json.dump(result, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for line in result.get("lines", [str(result)]):
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/deeploop/mission/mission_decision_engine.py
+++ b/src/deeploop/mission/mission_decision_engine.py
@@ -395,12 +395,9 @@ class MissionDecisionEngine:
         if not mission_id or not current_phase:
             raise ValueError("mission_state must include non-empty mission_id and current_phase")
 
-        # ── Tree-search-based action selection (opt-in via enable_tree_search) ──
+        # ── Tree-search-based action selection (on by default; opt-out via enable_tree_search: false) ──
         tree_phases = {"experiment-design", "execution"}
-        tree_enabled = bool(
-            mission_state.get("enable_tree_search")
-            or isinstance(mission_state.get("experiment_tree"), dict)
-        )
+        tree_enabled = mission_state.get("enable_tree_search") is not False
         if current_phase in tree_phases and tree_enabled:
             outcome = self._tree_search_decision(mission_state, mission_id, current_phase)
             if outcome is not None:

--- a/src/deeploop/runtime/provider_launcher.py
+++ b/src/deeploop/runtime/provider_launcher.py
@@ -72,28 +72,30 @@ def resolve_model_for_role(
     phase: str | None = None,
     explicit_model: str | None = None,
     tiers_config: Path | None = None,
+    provider_family: str = "openai-compatible-api",
 ) -> str:
-    """Resolve which model identifier to use based on role and phase tier configuration.
+    """Resolve which model identifier to use based on role, phase, and provider family.
 
     Resolution order:
     1. If ``explicit_model`` is provided, use it directly.
     2. Look up ``role`` in the model tiers config — first by direct role match,
        then by phase-to-role mapping.
     3. Fall back to the configured ``default_tier`` model.
-    4. Fall back to the ``OPENAI_MODEL`` environment variable.
-    5. Fall back to ``"deepseek-chat"`` as a last resort.
+    4. Fall back to the ``OPENAI_MODEL`` / ``ANTHROPIC_MODEL`` environment variable.
+    5. Fall back to ``"deepseek-chat"`` / ``"claude-sonnet-4-20250514"``.
+
+    When *provider_family* is ``"anthropic-api"``, the function prefers
+    ``model_identifier_anthropic`` over ``model_identifier`` from each tier.
 
     Args:
         role: The intended role (e.g. ``"planner"``, ``"execution-operator"``).
         phase: Optional phase name (e.g. ``"experiment-design"``, ``"execution"``).
-            When provided and the role is not directly listed in any tier, the
-            function attempts to match the phase to a tier instead.
         explicit_model: If set, bypasses tier resolution and returns this value.
-        tiers_config: Path to the model-tiers YAML configuration file. Defaults to
-            ``<REPO_ROOT>/configs/runtime/model-tiers.yaml``.
+        tiers_config: Path to the model-tiers YAML configuration file.
+        provider_family: One of ``"openai-compatible-api"`` or ``"anthropic-api"``.
 
     Returns:
-        A model identifier string (e.g. ``"deepseek-chat"``, ``"deepseek-reasoner"``).
+        A model identifier string.
     """
     if explicit_model:
         return explicit_model
@@ -112,6 +114,14 @@ def resolve_model_for_role(
     tiers_data: dict = raw if isinstance(raw, dict) else {}
     tiers: list[dict] = tiers_data.get("tiers", {})
     default_tier_name: str = str(tiers_data.get("default_tier", "execution"))
+    is_anthropic = provider_family == "anthropic-api"
+    identifier_key = "model_identifier_anthropic" if is_anthropic else "model_identifier"
+
+    def _resolve_identifier(cfg: dict) -> str | None:
+        identifier = cfg.get(identifier_key) or cfg.get("model_identifier")
+        if isinstance(identifier, str) and identifier:
+            return identifier
+        return None
 
     # --- Look up role in tiers ---
     for tier_name, tier_cfg in tiers.items():
@@ -119,9 +129,9 @@ def resolve_model_for_role(
             continue
         intended_roles = tier_cfg.get("intended_roles", [])
         if isinstance(intended_roles, list) and role in intended_roles:
-            identifier = tier_cfg.get("model_identifier")
-            if isinstance(identifier, str) and identifier:
-                return identifier
+            resolved = _resolve_identifier(tier_cfg)
+            if resolved:
+                return resolved
 
     # --- Fallback: look up phase in tiers ---
     if phase:
@@ -130,24 +140,25 @@ def resolve_model_for_role(
                 continue
             intended_phases = tier_cfg.get("intended_phases", [])
             if isinstance(intended_phases, list) and phase in intended_phases:
-                identifier = tier_cfg.get("model_identifier")
-                if isinstance(identifier, str) and identifier:
-                    return identifier
+                resolved = _resolve_identifier(tier_cfg)
+                if resolved:
+                    return resolved
 
     # --- Fallback to default tier ---
     if default_tier_name in tiers:
         default_cfg = tiers[default_tier_name]
         if isinstance(default_cfg, dict):
-            identifier = default_cfg.get("model_identifier")
-            if isinstance(identifier, str) and identifier:
-                return identifier
+            resolved = _resolve_identifier(default_cfg)
+            if resolved:
+                return resolved
 
     # --- Fallback to env var ---
-    env_model = os.environ.get("OPENAI_MODEL", "").strip()
+    env_var = "ANTHROPIC_MODEL" if is_anthropic else "OPENAI_MODEL"
+    env_model = os.environ.get(env_var, "").strip()
     if env_model:
         return env_model
 
-    return "deepseek-chat"
+    return "claude-sonnet-4-20250514" if is_anthropic else "deepseek-chat"
 
 
 def _load_json_file(path: Path) -> dict[str, object] | None:


### PR DESCRIPTION
## v0.4.0

### Changes

**Tree search enabled by default:**
- `experiment-design` and `execution` phases now use `ExperimentTree` automatically
- No opt-in flag required — set `enable_tree_search: false` to opt out

**Anthropic model tiers:**
- `model-tiers.yaml`: added `model_identifier_anthropic` for Claude models
- `resolve_model_for_role()`: new `provider_family` parameter selects provider-appropriate model
- Pricing table updated with Claude Sonnet/Opus rates

**Research module scripts restored:**
- `run_statistical_rigor.py` and `run_utility_scorer.py` scripts recreated (deleted in v0.3.0)

### Verification
- `repo-check` ✅
- Anthropic model resolution: `claude-opus-4-20250514` for reasoning tier ✅
- Tree search default: on for experiment-design/execution phases ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)