### PR TITLE
fix: disable tree search in test fixtures, increase iteration budgets

### DIFF
--- a/tests/test_mission_runtime.py
+++ b/tests/test_mission_runtime.py
@@ -72,6 +72,7 @@ def _base_state(*, mission_id: str, current_phase: str, next_phase: str, actions
         "roles": ["execution-operator", "critic-verifier", "report-synthesizer"],
         "next_actions": {"actions": actions},
         "autonomy_status": {"state": "initialized", "reason": "test"},
+        "enable_tree_search": False,
     }
 
 

--- a/tests/test_project_runner.py
+++ b/tests/test_project_runner.py
@@ -37,7 +37,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
         result = {
             "status": "operator-review-required",
@@ -81,7 +81,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
         result = {
             "status": "bootstrap-repair-required",
@@ -118,7 +118,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
         result = {
             "status": "mission-readiness-required",
@@ -157,7 +157,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
         result = {
             "status": "completed",
@@ -186,7 +186,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
         provider_result = {
             "status": "provider-readiness-required",
@@ -231,7 +231,7 @@ class ProjectRunnerTests(unittest.TestCase):
             force=False,
             until_complete=True,
             chunk_iterations=4,
-            max_total_iterations=12,
+            max_total_iterations=24,
         )
 
         with redirect_stdout(stdout), redirect_stderr(stderr):
@@ -313,7 +313,7 @@ class ProjectRunnerTests(unittest.TestCase):
                 project_root,
                 force=True,
                 chunk_iterations=4,
-                max_total_iterations=12,
+                max_total_iterations=24,
             )
 
         self.assertEqual(result["status"], "completed")

--- a/tests/test_public_bootstrap.py
+++ b/tests/test_public_bootstrap.py
@@ -266,7 +266,7 @@ class PublicBootstrapTests(unittest.TestCase):
             mission_id="public-bootstrap-example-mission",
             force=True,
             chunk_iterations=4,
-            max_total_iterations=32,
+            max_total_iterations=48,
         )
         self.addCleanup(lambda: shutil.rmtree(Path(result["mission_root"]), ignore_errors=True))
 


### PR DESCRIPTION
## Summary
v0.4.0 enabled tree search by default, which broke tests that rely on deterministic linear phase transitions and fixed iteration budgets.

## Changes
- `test_mission_runtime.py`: add `enable_tree_search: False` to `_base_state()` so integration tests use linear logic
- `test_project_runner.py`: bump `max_total_iterations` 12→24
- `test_public_bootstrap.py`: bump `max_total_iterations` 32→48

## Test Results (local)
- integration tests: pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)