### PR TITLE
fix: disable tree search in remaining integration test fixtures

### DIFF
--- a/tests/test_mission_runtime.py
+++ b/tests/test_mission_runtime.py
@@ -1320,6 +1320,7 @@ class MissionRuntimeTests(unittest.TestCase):
                 "target_repo": str(REPO_ROOT),
                 "completed_phases": [],
                 "phase_history": ["idea-intake"],
+                "enable_tree_search": False,
                 "roles": [
                     "planner",
                     "literature-scout",
@@ -1471,6 +1472,7 @@ class MissionRuntimeTests(unittest.TestCase):
                 "target_repo": str(REPO_ROOT),
                 "completed_phases": [],
                 "phase_history": ["idea-intake"],
+                "enable_tree_search": False,
                 "roles": [
                     "planner",
                     "literature-scout",


### PR DESCRIPTION
## Summary
Two integration tests were still hitting max-iterations with tree search default enabled. Add enable_tree_search: False to their inline mission state fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)