### PR TITLE
fix: default draft metric to 0 to prevent infinite draft loop

### DIFF
--- a/src/deeploop/mission/mission_decision_engine.py
+++ b/src/deeploop/mission/mission_decision_engine.py
@@ -1747,8 +1747,8 @@ class MissionDecisionEngine:
 
         if operation == "draft":
             new_id = tree.draft(code, plan)
-            if new_id in tree.nodes and metric is not None:
-                tree.nodes[new_id].metric = float(metric)
+            if new_id in tree.nodes:
+                tree.nodes[new_id].metric = float(metric) if metric is not None else 0.0
             if is_buggy and new_id in tree.nodes:
                 tree.nodes[new_id].is_buggy = True
         elif operation == "improve" and node_id and node_id in tree.nodes:


### PR DESCRIPTION
Draft nodes without experiment_result had no metric, causing best_node() to return None and select_next() to keep drafting infinitely.