### PR TITLE
fix: revert tree search to opt-in

### DIFF
--- a/src/deeploop/mission/mission_decision_engine.py
+++ b/src/deeploop/mission/mission_decision_engine.py
@@ -395,11 +395,11 @@ class MissionDecisionEngine:
         if not mission_id or not current_phase:
             raise ValueError("mission_state must include non-empty mission_id and current_phase")
 
-        # ── Tree-search-based action selection (on by default for missions with recursive-agent config; opt-out via enable_tree_search: false) ──
+        # ── Tree-search-based action selection (opt-in via enable_tree_search: true) ──
         tree_phases = {"experiment-design", "execution"}
-        tree_enabled = mission_state.get("enable_tree_search") is not False and (
-            isinstance(mission_state.get("experiment_tree"), dict)
-            or bool(self._resolve_recursive_config_path(mission_state))
+        tree_enabled = bool(
+            mission_state.get("enable_tree_search")
+            or isinstance(mission_state.get("experiment_tree"), dict)
         )
         if current_phase in tree_phases and tree_enabled:
             outcome = self._tree_search_decision(mission_state, mission_id, current_phase)


### PR DESCRIPTION
Tree search caused CI instability when on by default. Reverted to opt-in via enable_tree_search: true.