### PR TITLE
Fix #111 — State machine phase output name mismatch infinite loop

### DIFF
--- a/configs/autonomy/state-machine.yaml
+++ b/configs/autonomy/state-machine.yaml
@@ -31,22 +31,23 @@ states:
       - experiment-design
   - id: experiment-design
     outputs:
-      - run manifest draft
-      - execution profile selection
-      - resource tier selection
+      - manifest.json
+      - execution_profile.json
+      - resource_tier.json
     transitions:
       - execution
   - id: execution
     outputs:
-      - run logs
-      - metrics
-      - crash / stability notes
+      - run_manifest.json
+      - predictions.jsonl
+      - metrics.json
+      - runtime_report.json
     transitions:
       - critique
   - id: critique
     outputs:
-      - evidence assessment
-      - confound notes
+      - critique_evidence.json
+      - confound_notes
       - next-step recommendation
     transitions:
       - experiment-design

--- a/src/deeploop/mission/orchestrator.py
+++ b/src/deeploop/mission/orchestrator.py
@@ -37,9 +37,9 @@ ROLE_OUTPUTS = {
     "planner": ["mission plan updates", "phase transitions"],
     "literature-scout": ["prior-art notes", "benchmark watchlists"],
     "dataset-strategist": ["dataset promotion plans", "slice notes"],
-    "experiment-designer": ["manifest drafts", "baseline configs"],
-    "execution-operator": ["run manifests", "metrics", "logs"],
-    "critic-verifier": ["critique summaries", "evidence-state recommendations"],
+    "experiment-designer": ["manifest.json", "execution_profile.json", "resource_tier.json"],
+    "execution-operator": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+    "critic-verifier": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
     "report-synthesizer": ["findings summaries", "paper-ready notes"],
 }
 DATASET_ARTIFACT_ROLES = {"dataset-strategist", "execution-operator"}

--- a/tests/test_artifact_packager.py
+++ b/tests/test_artifact_packager.py
@@ -789,7 +789,7 @@ class ArtifactPackagerTests(unittest.TestCase):
                     "generated_configs": [],
                 },
                 "phase_outputs_by_phase": {
-                    "execution": ["run logs", "metrics", "crash / stability notes"],
+                    "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                 },
                 "agent_driver": {
                     "memory_path": str(memory_path),
@@ -871,7 +871,7 @@ class ArtifactPackagerTests(unittest.TestCase):
             )
             self.assertFalse(
                 any(
-                    "crash / stability notes" in item
+                    "runtime_report.json" in item
                     or str((output_root / "recursive-output-package-mission" / "mission_artifact_package.json").resolve()) in item
                     or str((output_root / "recursive-output-package-mission" / "mission_artifact_package.md").resolve()) in item
                     for item in package["claim_summary"]["release_candidate_blockers"]

--- a/tests/test_mission_decision_engine.py
+++ b/tests/test_mission_decision_engine.py
@@ -106,16 +106,16 @@ class MissionDecisionEngineTests(unittest.TestCase):
 
     def test_engine_synthesizes_current_phase_work_for_missing_outputs(self) -> None:
         mission_state = _base_state(current_phase="critique", next_phase="experiment-design")
-        evidence = MissionEvidence(produced_outputs=("evidence assessment",))
+        evidence = MissionEvidence(produced_outputs=("critique_evidence.json",))
 
         outcome = self.engine.decide(mission_state, evidence=evidence)
 
         self.assertEqual(outcome.directive, MissionDecisionDirective.CONTINUE)
-        self.assertEqual(set(outcome.missing_outputs), {"confound notes", "next-step recommendation"})
+        self.assertEqual(set(outcome.missing_outputs), {"confound_notes", "next-step recommendation"})
         self.assertIsNotNone(outcome.action)
         assert outcome.action is not None
         self.assertEqual(outcome.action.role, "critic-verifier")
-        self.assertIn("confound notes", outcome.action.task)
+        self.assertIn("confound_notes", outcome.action.task)
 
     def test_engine_downscopes_repeated_artifact_failures_to_planner(self) -> None:
         mission_state = _base_state(current_phase="literature-review", next_phase="question-design")
@@ -133,7 +133,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
     def test_engine_reroutes_through_recovery_transition(self) -> None:
         mission_state = _base_state(current_phase="critique", next_phase="experiment-design")
         evidence = MissionEvidence(
-            produced_outputs=("evidence assessment", "confound notes", "next-step recommendation"),
+            produced_outputs=("critique_evidence.json", "confound_notes", "next-step recommendation"),
             recent_failures=("failed-1", "failed-2", "failed-3"),
             failure_count=4,
         )
@@ -227,8 +227,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="final-report", next_phase="final-report")
         mission_state["completed_phases"] = ["idea-intake", "literature-review", "question-design", "experiment-design", "execution", "critique", "replication"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
@@ -248,7 +248,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="final-report", next_phase="final-report")
         mission_state["completed_phases"] = ["idea-intake", "literature-review", "question-design", "experiment-design", "critique", "replication"]
         mission_state["phase_outputs_by_phase"] = {
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
@@ -261,14 +261,14 @@ class MissionDecisionEngineTests(unittest.TestCase):
 
         self.assertEqual(outcome.directive, MissionDecisionDirective.BLOCK)
         self.assertIn("completion contract requires completed phase `execution`", outcome.notes)
-        self.assertIn("completion contract missing `execution` output `run logs`", outcome.notes)
+        self.assertIn("completion contract missing `execution` output `run_manifest.json`", outcome.notes)
 
     def test_engine_blocks_final_report_transition_when_acceptance_criteria_are_unmet(self) -> None:
         mission_state = _base_state(current_phase="replication", next_phase="final-report")
         mission_state["completed_phases"] = ["execution", "critique"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
         }
         mission_state["acceptance_criteria"] = {
@@ -289,8 +289,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="replication", next_phase="final-report")
         mission_state["completed_phases"] = ["execution", "critique"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
         }
         mission_state["acceptance_criteria"] = {
@@ -324,8 +324,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
             "replication",
         ]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
@@ -350,8 +350,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="final-report", next_phase="final-report")
         mission_state["completed_phases"] = ["idea-intake", "literature-review", "question-design", "experiment-design", "execution", "critique"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
         mission_state["completion_contract"] = {
@@ -372,8 +372,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="final-report", next_phase="final-report")
         mission_state["completed_phases"] = ["idea-intake", "literature-review", "question-design", "experiment-design", "execution", "critique"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
         mission_state["branch_closure_mode"] = "no-win-under-budget"
@@ -392,8 +392,8 @@ class MissionDecisionEngineTests(unittest.TestCase):
         mission_state = _base_state(current_phase="final-report", next_phase="final-report")
         mission_state["completed_phases"] = ["idea-intake", "literature-review", "question-design", "experiment-design", "execution", "critique"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "final-report": ["findings summary", "paper-candidate recommendation", "artifact readiness notes"],
         }
         mission_state["final_report"] = {
@@ -430,7 +430,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
             ],
         )
         evidence = MissionEvidence(
-            produced_outputs=("run logs", "metrics", "crash / stability notes"),
+            produced_outputs=("run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"),
         )
 
         outcome = self.engine.decide(mission_state, evidence=evidence)
@@ -461,7 +461,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
         }
         mission_state["adaptation_training"] = {"metric_ratchet": {"decision": "keep", "route_to": "replication"}}
         evidence = MissionEvidence(
-            produced_outputs=("evidence assessment", "confound notes", "next-step recommendation"),
+            produced_outputs=("critique_evidence.json", "confound_notes", "next-step recommendation"),
         )
 
         outcome = self.engine.decide(mission_state, evidence=evidence)
@@ -488,7 +488,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
         }
         mission_state["adaptation_training"] = {"metric_ratchet": {"decision": "discard", "route_to": "experiment-design"}}
         evidence = MissionEvidence(
-            produced_outputs=("evidence assessment", "confound notes", "next-step recommendation"),
+            produced_outputs=("critique_evidence.json", "confound_notes", "next-step recommendation"),
             recent_failures=("failed-1", "failed-2", "failed-3"),
             failure_count=4,
         )
@@ -515,7 +515,7 @@ class MissionDecisionEngineTests(unittest.TestCase):
             }
         }
         evidence = MissionEvidence(
-            produced_outputs=("evidence assessment", "confound notes", "next-step recommendation"),
+            produced_outputs=("critique_evidence.json", "confound_notes", "next-step recommendation"),
         )
 
         with self.assertRaisesRegex(ValueError, "Deterministic routes must declare `when`"):

--- a/tests/test_mission_monitor.py
+++ b/tests/test_mission_monitor.py
@@ -243,7 +243,7 @@ class MissionMonitorTests(unittest.TestCase):
                     "selected_action_ids": ["run-baseline"],
                     "selected_branch_ids": [],
                     "artifacts": [],
-                    "notes": ["missing output: run logs", "missing output: metrics"],
+                    "notes": ["missing output: run_manifest.json", "missing output: metrics.json"],
                 },
                 {
                     "decision_id": "demo-critique-missing-outputs",
@@ -257,7 +257,7 @@ class MissionMonitorTests(unittest.TestCase):
                     "selected_action_ids": ["critique-missing-outputs"],
                     "selected_branch_ids": [],
                     "artifacts": [],
-                    "notes": ["missing output: evidence assessment"],
+                    "notes": ["missing output: critique_evidence.json"],
                 },
             ],
         )
@@ -507,7 +507,7 @@ class MissionMonitorTests(unittest.TestCase):
                             "branch_id": "analysis-critique",
                             "runtime_owner": "deeploop",
                             "requires_operator_approval": False,
-                            "notes": ["missing output: evidence assessment", "Awaiting critique outputs."],
+                            "notes": ["missing output: critique_evidence.json", "Awaiting critique outputs."],
                         },
                     ],
                 },
@@ -525,7 +525,7 @@ class MissionMonitorTests(unittest.TestCase):
                     }
                 ],
                 "runtime_recovery": {"report_json_path": str(runtime_report_path)},
-                "phase_outputs_by_phase": {"execution": ["run logs", "metrics"]},
+                "phase_outputs_by_phase": {"execution": ["run_manifest.json", "metrics"]},
                 "produced_outputs": [],
                 "recent_failures": ["Executor `stage-kernel` previously timed out."],
                 "failure_count": 1,

--- a/tests/test_mission_runtime.py
+++ b/tests/test_mission_runtime.py
@@ -173,11 +173,11 @@ class MissionRuntimeTests(unittest.TestCase):
             "critique",
         ]
         mission_state["phase_outputs_by_phase"] = {
-            "experiment-design": ["run manifest draft", "execution profile selection"],
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "experiment-design": ["manifest.json", "execution_profile.json"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
         }
-        mission_state["produced_outputs"] = ["evidence assessment", "confound notes", "next-step recommendation"]
+        mission_state["produced_outputs"] = ["critique_evidence.json", "confound_notes", "next-step recommendation"]
         mission_state["phase_outputs"] = list(mission_state["produced_outputs"])
 
         _apply_phase_change(
@@ -234,9 +234,9 @@ class MissionRuntimeTests(unittest.TestCase):
                 "action_id": "close-experiment-design",
                 "phase": "experiment-design",
                 "produces_outputs": [
-                    "run manifest draft",
-                    "execution profile selection",
-                    "resource tier selection",
+                    "manifest.json",
+                    "execution_profile.json",
+                    "resource_tier.json",
                 ],
             },
             result=result,
@@ -349,7 +349,7 @@ class MissionRuntimeTests(unittest.TestCase):
                                 "id": "recursive-agent",
                                 "params": {"config_path": "configs/runtime/demo-recursive.yaml"},
                             },
-                            "produces_outputs": ["run logs", "metrics", "crash / stability notes"],
+                            "produces_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                         }
                     ],
                 ),
@@ -378,7 +378,7 @@ class MissionRuntimeTests(unittest.TestCase):
                 status="completed",
                 summary="Recovered execution outputs after bounded retry.",
                 payload={
-                    "produced_outputs": ["run logs", "metrics", "crash / stability notes"],
+                    "produced_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                     "phase_control": {
                         "current_phase": "execution",
                         "next_phase": "critique",
@@ -397,7 +397,7 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertEqual(mission_state["failure_count"], 1)
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["execution"],
-            ["run logs", "metrics", "crash / stability notes"],
+            ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
         )
 
     @patch("deeploop.mission.mission_runtime.run_mission_action")
@@ -425,7 +425,7 @@ class MissionRuntimeTests(unittest.TestCase):
                                 "id": "recursive-agent",
                                 "params": {"config_path": "configs/runtime/demo-recursive.yaml"},
                             },
-                            "produces_outputs": ["evidence assessment", "confound notes", "next-step recommendation"],
+                            "produces_outputs": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                         }
                     ],
                 ),
@@ -454,7 +454,7 @@ class MissionRuntimeTests(unittest.TestCase):
                 status="completed",
                 summary="Recovered critique outputs after bounded retry.",
                 payload={
-                    "produced_outputs": ["evidence assessment", "confound notes", "next-step recommendation"],
+                    "produced_outputs": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                     "phase_control": {
                         "current_phase": "critique",
                         "next_phase": "replication",
@@ -473,7 +473,7 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertEqual(mission_state["failure_count"], 1)
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["critique"],
-            ["evidence assessment", "confound notes", "next-step recommendation"],
+            ["critique_evidence.json", "confound_notes", "next-step recommendation"],
         )
 
     @patch("deeploop.runtime.mission_executor_registry.run_stage_from_config")
@@ -503,7 +503,7 @@ class MissionRuntimeTests(unittest.TestCase):
                                 "config_path": "configs/runtime/demo-stage.yaml",
                             },
                         },
-                        "produces_outputs": ["run logs", "metrics", "crash / stability notes"],
+                        "produces_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                     }
                 ],
             ),
@@ -532,7 +532,7 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertEqual(mission_state["next_actions"]["actions"][2]["status"], "blocked")
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["execution"],
-            ["run logs", "metrics", "crash / stability notes"],
+            ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
         )
         decision_log = (mission_state_path.parent / "mission_decisions.jsonl").read_text(encoding="utf-8").splitlines()
         self.assertEqual(len([line for line in decision_log if line.strip()]), 3)
@@ -541,7 +541,7 @@ class MissionRuntimeTests(unittest.TestCase):
         mission_memory = json.loads((mission_state_path.parent / "mission_memory.json").read_text(encoding="utf-8"))
         self.assertEqual(len(mission_memory["branch_registry"]), 1)
         self.assertEqual(next(iter(mission_memory["branch_registry"].values()))["status"], "critique-ready")
-        self.assertEqual(mission_memory["completed_phase_outputs"]["execution"], ["run logs", "metrics", "crash / stability notes"])
+        self.assertEqual(mission_memory["completed_phase_outputs"]["execution"], ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"])
         self.assertEqual(mission_memory["counts"]["evidence_snapshots"], 3)
         experiment_entries = [
             json.loads(line)
@@ -585,7 +585,7 @@ class MissionRuntimeTests(unittest.TestCase):
                                 "config_path": "configs/runtime/demo-stage.yaml",
                             },
                         },
-                        "produces_outputs": ["run logs", "metrics", "crash / stability notes"],
+                        "produces_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                     }
                 ],
             ),
@@ -660,8 +660,8 @@ class MissionRuntimeTests(unittest.TestCase):
             ]
             state["phase_outputs"] = list(state["produced_outputs"])
             state["phase_outputs_by_phase"] = {
-                "execution": ["run logs", "metrics", "crash / stability notes"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                 "replication": ["repeated-run manifests", "replication summary"],
                 "final-report": list(state["produced_outputs"]),
             }
@@ -823,8 +823,8 @@ class MissionRuntimeTests(unittest.TestCase):
             ]
             state["phase_outputs"] = list(state["produced_outputs"])
             state["phase_outputs_by_phase"] = {
-                "execution": ["run logs", "metrics", "crash / stability notes"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                 "final-report": list(state["produced_outputs"]),
             }
             state["branch_closure_mode"] = "no-win-under-budget"
@@ -914,8 +914,8 @@ class MissionRuntimeTests(unittest.TestCase):
             ]
             state["phase_outputs"] = list(state["produced_outputs"])
             state["phase_outputs_by_phase"] = {
-                "execution": ["run logs", "metrics", "crash / stability notes"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                 "final-report": list(state["produced_outputs"]),
             }
             _write_json(mission_state_path, state)
@@ -989,8 +989,8 @@ class MissionRuntimeTests(unittest.TestCase):
         ]
         mission_state["phase_history"] = list(mission_state["completed_phases"]) + ["final-report"]
         mission_state["phase_outputs_by_phase"] = {
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
         }
         _write_json(mission_state_path, mission_state)
@@ -1044,11 +1044,11 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertEqual(mission_state["status"], "completed")
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["execution"],
-            ["run logs", "metrics", "crash / stability notes"],
+            ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
         )
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["critique"],
-            ["evidence assessment", "confound notes", "next-step recommendation"],
+            ["critique_evidence.json", "confound_notes", "next-step recommendation"],
         )
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["replication"],
@@ -1099,8 +1099,8 @@ class MissionRuntimeTests(unittest.TestCase):
             "report_json_path": runtime_root / "report.json",
             "report_markdown_path": runtime_root / "report.md",
             "produced_outputs": [
-                "evidence assessment",
-                "confound notes",
+                "critique_evidence.json",
+                "confound_notes",
                 "next-step recommendation",
             ],
             "latest_outcome": {
@@ -1121,7 +1121,7 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertEqual(mission_state["next_actions"]["actions"][0]["status"], "completed")
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["critique"],
-            ["evidence assessment", "confound notes", "next-step recommendation"],
+            ["critique_evidence.json", "confound_notes", "next-step recommendation"],
         )
         mission_memory = json.loads((mission_state_path.parent / "mission_memory.json").read_text(encoding="utf-8"))
         self.assertEqual(mission_memory["latest_experiment"]["executor_id"], "recursive-agent")
@@ -1170,8 +1170,8 @@ class MissionRuntimeTests(unittest.TestCase):
             ]
             state["phase_outputs"] = list(state["produced_outputs"])
             state["phase_outputs_by_phase"] = {
-                "execution": ["run logs", "metrics", "crash / stability notes"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                 "replication": ["repeated-run manifests", "replication summary"],
                 "final-report": list(state["produced_outputs"]),
             }
@@ -1238,7 +1238,7 @@ class MissionRuntimeTests(unittest.TestCase):
                             "id": "self-healing-queue",
                             "params": {"config_path": str(queue_config_path)},
                         },
-                        "produces_outputs": ["run logs", "metrics", "crash / stability notes"],
+                        "produces_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                     }
                 },
             },
@@ -1376,8 +1376,8 @@ class MissionRuntimeTests(unittest.TestCase):
                 "literature-review": ["prior-art memo", "benchmark and method watchlist"],
                 "question-design": ["hypotheses", "evaluation targets"],
                 "benchmark-selection": ["dataset shortlist", "slice plan"],
-                "experiment-design": ["run manifest draft", "execution profile selection", "resource tier selection"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "experiment-design": ["manifest.json", "execution_profile.json", "resource_tier.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             }
             next_phase = {
                 "question-design": "benchmark-selection",
@@ -1523,9 +1523,9 @@ class MissionRuntimeTests(unittest.TestCase):
                 "literature-review": ["prior-art memo", "benchmark and method watchlist"],
                 "question-design": ["hypotheses", "evaluation targets"],
                 "benchmark-selection": ["dataset shortlist", "slice plan"],
-                "experiment-design": ["run manifest draft", "execution profile selection", "resource tier selection"],
-                "execution": ["run logs", "metrics", "crash / stability notes"],
-                "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+                "experiment-design": ["manifest.json", "execution_profile.json", "resource_tier.json"],
+                "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+                "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
                 "replication": ["repeated-run manifests", "replication summary"],
             }
             next_phase = {
@@ -1574,7 +1574,7 @@ class MissionRuntimeTests(unittest.TestCase):
         self.assertIn("replication", mission_state["completed_phases"])
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["execution"],
-            ["run logs", "metrics", "crash / stability notes"],
+            ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
         )
         self.assertEqual(
             mission_state["phase_outputs_by_phase"]["replication"],
@@ -2141,7 +2141,7 @@ class MissionRuntimeTests(unittest.TestCase):
                                     "config_path": "configs/runtime/demo-stage.yaml",
                                 },
                             },
-                            "produces_outputs": ["run logs", "metrics", "crash / stability notes"],
+                            "produces_outputs": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
                         },
                         {
                             "action_id": "decide-replication-readiness",
@@ -2162,8 +2162,8 @@ class MissionRuntimeTests(unittest.TestCase):
                                 },
                             },
                             "produces_outputs": [
-                                "evidence assessment",
-                                "confound notes",
+                                "critique_evidence.json",
+                                "confound_notes",
                                 "next-step recommendation",
                             ],
                         },

--- a/tests/test_project_runner.py
+++ b/tests/test_project_runner.py
@@ -692,9 +692,9 @@ class ProjectRunnerTests(unittest.TestCase):
             "literature-review": ["prior-art memo", "benchmark and method watchlist"],
             "question-design": ["hypotheses", "evaluation targets"],
             "benchmark-selection": ["dataset shortlist", "slice plan"],
-            "experiment-design": ["run manifest draft", "execution profile selection", "resource tier selection"],
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "experiment-design": ["manifest.json", "execution_profile.json", "resource_tier.json"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
         }
 
@@ -825,7 +825,7 @@ class ProjectRunnerTests(unittest.TestCase):
             "literature-review": ["prior-art memo", "benchmark and method watchlist"],
             "question-design": ["hypotheses", "evaluation targets"],
             "benchmark-selection": ["dataset shortlist", "slice plan"],
-            "experiment-design": ["run manifest draft", "execution profile selection", "resource tier selection"],
+            "experiment-design": ["manifest.json", "execution_profile.json", "resource_tier.json"],
         }
 
         def _fake_recursive_runtime(config_path: Path) -> dict:

--- a/tests/test_public_bootstrap.py
+++ b/tests/test_public_bootstrap.py
@@ -213,9 +213,9 @@ class PublicBootstrapTests(unittest.TestCase):
             "literature-review": ["prior-art memo", "benchmark and method watchlist"],
             "question-design": ["hypotheses", "evaluation targets"],
             "benchmark-selection": ["dataset shortlist", "slice plan"],
-            "experiment-design": ["run manifest draft", "execution profile selection", "resource tier selection"],
-            "execution": ["run logs", "metrics", "crash / stability notes"],
-            "critique": ["evidence assessment", "confound notes", "next-step recommendation"],
+            "experiment-design": ["manifest.json", "execution_profile.json", "resource_tier.json"],
+            "execution": ["run_manifest.json", "predictions.jsonl", "metrics.json", "runtime_report.json"],
+            "critique": ["critique_evidence.json", "confound_notes", "next-step recommendation"],
             "replication": ["repeated-run manifests", "replication summary"],
         }
 


### PR DESCRIPTION
## Summary

Fixes #111: the state machine expected human-readable output names (e.g. "run manifest draft", "evidence assessment") but the recursive agent and executors produced filenames (e.g. "manifest.json", "critique_evidence.json"). This mismatch caused the outer loop to always detect missing outputs, triggering soft-gate recovery loops that cycled phases forever.

## Changes

- **state-machine.yaml**: Output names updated to match actual executor filenames
- **orchestrator.py**: `ROLE_OUTPUTS` updated to match
- **Tests**: All 5 affected test files updated to use new output names

## Test Results

```
Ran 703 tests in 58.8s — 0 new regressions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)