### PR TITLE
Fix #114 + audit — fast-fail credentials, token tracking, state safety

### DIFF
--- a/src/deeploop/mission/mission_management.py
+++ b/src/deeploop/mission/mission_management.py
@@ -993,14 +993,7 @@ def _handle_start(args: argparse.Namespace) -> int:
             # 1. Ensure workspace dirs exist (fold in setup)
             ensure_expected_external_dirs()
 
-            # 2. Check provider readiness
-            report = check_provider_readiness(selection_profile="deepseek-chat-control-plane")
-            if report["status"] != "ready":
-                print(f"Provider not ready: {report['next_step']}")
-                print(f"  Run: {report.get('recheck_command', 'deeploop provider-ready')}")
-                return 1
-
-            # 3. Get idea text
+            # 2. Get idea text
             idea = getattr(args, "idea", None)
             if not idea:
                 print("Usage: deeploop start \"your research idea\"")
@@ -1042,6 +1035,13 @@ def _handle_start(args: argparse.Namespace) -> int:
             print(f"Provider ready (deepseek-chat)")
             print(f"Project bootstrapped ({mission_state_path.parent.name})")
             print(f"Running — deeploop status for progress")
+
+    # Provider readiness check — fail fast before launching daemon
+    report = check_provider_readiness(selection_profile="deepseek-chat-control-plane")
+    if report["status"] != "ready":
+        print(f"Provider not ready: {report['next_step']}")
+        print(f"  Run: {report.get('recheck_command', 'deeploop provider-ready')}")
+        return 1
 
     mission_state_path = _resolve_existing_path(args.mission_state)
     resume_context = None
@@ -1166,6 +1166,7 @@ def _handle_triage(args: argparse.Namespace) -> int:
         cwd=Path(target_repo).expanduser().resolve() if target_repo else REPO_ROOT,
         capture_output=True,
         text=True,
+        timeout=300,
         check=False,
     )
     completed_at = now_utc()

--- a/src/deeploop/mission/mission_runtime.py
+++ b/src/deeploop/mission/mission_runtime.py
@@ -228,9 +228,19 @@ def default_stop_conditions(
 # ---------------------------------------------------------------------------
 
 _MODEL_PRICING: dict[str, dict[str, float]] = {
+    # DeepSeek (per 1M tokens, USD)
     "deepseek-chat": {"input": 0.27, "output": 1.10},
     "deepseek-reasoner": {"input": 0.55, "output": 2.19},
+    "deepseek-v4-pro": {"input": 0.27, "output": 1.10},
+    # Anthropic Claude (per 1M tokens, USD)
+    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
+    "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
+    "claude-fable-5": {"input": 15.00, "output": 75.00},
 }
+
+# Track which models we've already warned about to avoid log spam
+_UNPRICED_MODEL_WARNED: set[str] = set()
 
 def tokenCountIs(max_tokens: int) -> StopCondition:
     """Stop when total_tokens across all calls reaches *max_tokens*."""
@@ -281,6 +291,15 @@ def accumulate_cost(runtime_state: dict, model: str, input_tokens: int, output_t
     """
     pricing = _MODEL_PRICING.get(model)
     if pricing is None:
+        if model and model not in _UNPRICED_MODEL_WARNED:
+            _UNPRICED_MODEL_WARNED.add(model)
+            import sys as _sys
+            print(
+                f"[deeploop] WARNING: Model `{model}` is not in the pricing table. "
+                f"Cost tracking will be inaccurate. Add pricing to _MODEL_PRICING "
+                f"in mission_runtime.py.",
+                file=_sys.stderr,
+            )
         return float(runtime_state.get("accumulated_cost", 0.0))
     cost = (input_tokens / 1_000_000) * pricing["input"] + (output_tokens / 1_000_000) * pricing["output"]
     current = float(runtime_state.get("accumulated_cost", 0.0))
@@ -2388,7 +2407,13 @@ def run_mission(
                 runtime_state["total_tokens"] = int(runtime_state.get("total_tokens", 0) or 0) + input_tokens + output_tokens
                 runtime_state["total_input_tokens"] = int(runtime_state.get("total_input_tokens", 0) or 0) + input_tokens
                 runtime_state["total_output_tokens"] = int(runtime_state.get("total_output_tokens", 0) or 0) + output_tokens
-                accumulate_cost(runtime_state, os.environ.get("OPENAI_MODEL", "deepseek-chat"), input_tokens, output_tokens)
+                # Use the executor's actual model if available, else fall back to env
+                cost_model = (
+                    executor_payload.get("model")
+                    or runtime_state.get("last_executor_model")
+                    or os.environ.get("OPENAI_MODEL", "deepseek-chat")
+                )
+                accumulate_cost(runtime_state, cost_model, input_tokens, output_tokens)
             if _skip_iteration:
                 continue
         else:

--- a/src/deeploop/runtime/anthropic_adapter.py
+++ b/src/deeploop/runtime/anthropic_adapter.py
@@ -80,7 +80,7 @@ def _extract_response_text(response_payload: dict[str, Any]) -> str:
     raise RuntimeError("Anthropic response did not include textual content")
 
 
-def _invoke_anthropic(prompt_text: str, *, model: str, json_only: bool = False) -> str:
+def _invoke_anthropic(prompt_text: str, *, model: str, json_only: bool = False) -> tuple[str, dict[str, int]]:
     request = Request(
         _messages_endpoint(),
         data=_request_payload(prompt_text, model=model, json_only=json_only),
@@ -102,7 +102,16 @@ def _invoke_anthropic(prompt_text: str, *, model: str, json_only: bool = False) 
         raise RuntimeError(f"Anthropic request failed: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise RuntimeError("Anthropic endpoint returned malformed JSON") from exc
-    return _extract_response_text(payload)
+    response_text = _extract_response_text(payload)
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        tokens = {
+            "input_tokens": int(usage.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage.get("output_tokens", 0) or 0),
+        }
+    else:
+        tokens = {"input_tokens": 0, "output_tokens": 0}
+    return response_text, tokens
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -120,10 +129,11 @@ def main(argv: list[str] | None = None) -> int:
     model = _resolved_model(args.model)
     json_only = args.result_json_path is not None
 
-    response_text = _invoke_anthropic(prompt_text, model=model, json_only=json_only)
+    response_text, tokens = _invoke_anthropic(prompt_text, model=model, json_only=json_only)
 
     if json_only:
         parsed = _extract_first_json_object(response_text)
+        parsed["tokens"] = tokens
         result_path = Path(args.result_json_path).expanduser().resolve()
         result_path.parent.mkdir(parents=True, exist_ok=True)
         result_path.write_text(json.dumps(parsed, indent=2) + "\n", encoding="utf-8")

--- a/src/deeploop/runtime/openai_compatible_adapter.py
+++ b/src/deeploop/runtime/openai_compatible_adapter.py
@@ -165,7 +165,7 @@ def _request_payload(prompt_text: str, *, model: str, json_only: bool = False) -
     return json.dumps(payload).encode("utf-8")
 
 
-def _invoke_openai_compatible(prompt_text: str, *, model: str, json_only: bool = False) -> str:
+def _invoke_openai_compatible(prompt_text: str, *, model: str, json_only: bool = False) -> tuple[str, dict[str, int]]:
     request = Request(
         _chat_completion_endpoint(),
         data=_request_payload(prompt_text, model=model, json_only=json_only),
@@ -197,7 +197,16 @@ def _invoke_openai_compatible(prompt_text: str, *, model: str, json_only: bool =
     first_choice = choices[0]
     if not isinstance(first_choice, dict):
         raise RuntimeError("OpenAI-compatible response choice was not an object")
-    return _extract_choice_response_text(first_choice)
+    response_text = _extract_choice_response_text(first_choice)
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        tokens = {
+            "input_tokens": int(usage.get("prompt_tokens", 0) or 0),
+            "output_tokens": int(usage.get("completion_tokens", 0) or 0),
+        }
+    else:
+        tokens = {"input_tokens": 0, "output_tokens": 0}
+    return response_text, tokens
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -209,7 +218,7 @@ def main(argv: list[str] | None = None) -> int:
 
     prompt_file = Path(args.prompt_file).expanduser().resolve()
     prompt_text = prompt_file.read_text(encoding="utf-8")
-    response_text = _invoke_openai_compatible(
+    response_text, tokens = _invoke_openai_compatible(
         prompt_text,
         model=_resolved_model(args.model),
         json_only=bool(args.result_json_path),
@@ -217,6 +226,7 @@ def main(argv: list[str] | None = None) -> int:
     print(response_text, end="" if response_text.endswith("\n") else "\n")
     if args.result_json_path:
         payload = _extract_first_json_object(response_text)
+        payload["tokens"] = tokens
         result_json_path = Path(args.result_json_path).expanduser().resolve()
         result_json_path.parent.mkdir(parents=True, exist_ok=True)
         result_json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/src/deeploop/runtime/recursive_agent_runtime.py
+++ b/src/deeploop/runtime/recursive_agent_runtime.py
@@ -656,14 +656,6 @@ def _effective_outcome(outcome: dict[str, Any] | None, loop_status: str) -> dict
     effective["action_result"] = action_result
     return effective
 
-    merged = dict(base)
-    for key, value in updates.items():
-        if isinstance(value, dict) and isinstance(merged.get(key), dict):
-            merged[key] = deep_merge(dict(merged[key]), value)
-        else:
-            merged[key] = value
-    return merged
-
 def _runtime_root(mission_state_path: Path, artifact_dir_name: str, loop_name: str) -> Path:
     return mission_state_path.parent / "runtime" / artifact_dir_name / loop_name
 

--- a/src/deeploop/runtime/self_healing_runtime.py
+++ b/src/deeploop/runtime/self_healing_runtime.py
@@ -13,6 +13,7 @@ import yaml
 
 from deeploop.core.ledger import append_jsonl, make_ledger_entry, now_utc
 from deeploop.core.paths import resolve_workspace_path
+from deeploop.mission.mission_state import write_mission_state
 from deeploop.core.paths import REPO_ROOT as DEEPLOOP_REPO_ROOT
 from deeploop.core.shared import build_command as _build_command, is_relative_to as _is_relative_to
 from deeploop.research.sanity_gates import evaluate_research_sanity, extract_proposal_config_path
@@ -635,7 +636,7 @@ def _update_mission_state(
         state = "runtime-completed"
         reason = "Queue completed without needing recovery."
     mission_state["autonomy_status"] = {"state": state, "reason": reason}
-    mission_state_path.write_text(json.dumps(mission_state, indent=2) + "\n", encoding="utf-8")
+    write_mission_state(mission_state_path, mission_state)
 
 def _entry_terminal_status(failure: dict[str, Any]) -> tuple[str, str | None]:
     if failure["kind"] == "scientific-failure":

--- a/tests/test_mission_management.py
+++ b/tests/test_mission_management.py
@@ -192,7 +192,9 @@ class MissionManagementTests(unittest.TestCase):
         self.assertEqual(args.format, "github-repo")
         self.assertTrue(args.force)
 
-    def test_start_launches_canonical_runtime_and_writes_metadata(self) -> None:
+    @patch("deeploop.mission.mission_management.check_provider_readiness",
+           return_value={"status": "ready"})
+    def test_start_launches_canonical_runtime_and_writes_metadata(self, _mock_check) -> None:
         test_root = _fresh_test_root("start_launches_runtime")
         mission_state_path = test_root / "mission" / "mission_state.json"
         launch_metadata_path = test_root / "launch" / "launch.json"
@@ -236,7 +238,9 @@ class MissionManagementTests(unittest.TestCase):
         self.assertIn("## Advanced commands", stdout.getvalue())
         self.assertIn("deeploop start", log_path.read_text(encoding="utf-8"))
 
-    def test_start_uses_configured_launch_env_when_present(self) -> None:
+    @patch("deeploop.mission.mission_management.check_provider_readiness",
+           return_value={"status": "ready"})
+    def test_start_uses_configured_launch_env_when_present(self, _mock_check) -> None:
         test_root = _fresh_test_root("start_uses_launch_env")
         mission_state_path = test_root / "mission" / "mission_state.json"
         launch_metadata_path = test_root / "launch" / "launch.json"
@@ -266,7 +270,9 @@ class MissionManagementTests(unittest.TestCase):
         self.assertEqual(command[:5], ["conda", "run", "-n", "llm", "python"])
         self.assertEqual(Path(command[5]).resolve(), REPO_ROOT / "scripts" / "mission" / "run_mission.py")
 
-    def test_start_uses_configured_max_iterations_when_cli_omitted(self) -> None:
+    @patch("deeploop.mission.mission_management.check_provider_readiness",
+           return_value={"status": "ready"})
+    def test_start_uses_configured_max_iterations_when_cli_omitted(self, _mock_check) -> None:
         test_root = _fresh_test_root("start_uses_configured_iterations")
         mission_state_path = test_root / "mission" / "mission_state.json"
         launch_metadata_path = test_root / "launch" / "launch.json"
@@ -296,7 +302,9 @@ class MissionManagementTests(unittest.TestCase):
         metadata = json.loads(launch_metadata_path.read_text(encoding="utf-8"))
         self.assertEqual(metadata["max_iterations"], 33)
 
-    def test_start_injects_runtime_cache_env_for_editable_install(self) -> None:
+    @patch("deeploop.mission.mission_management.check_provider_readiness",
+           return_value={"status": "ready"})
+    def test_start_injects_runtime_cache_env_for_editable_install(self, _mock_check) -> None:
         """When the package is editable, start should snapshot src and set DEEPLOOP_RUNTIME_CACHE_SRC."""
         import importlib.metadata as _meta
         from deeploop.mission.mission_management import _snapshot_src_for_mission
@@ -668,7 +676,9 @@ class MissionManagementTests(unittest.TestCase):
         self.assertIn("deeploop resume", stdout.getvalue())
         self.assertIn("operator_feedback: `retry`", stdout.getvalue())
 
-    def test_resume_surfaces_recorded_operator_feedback(self) -> None:
+    @patch("deeploop.mission.mission_management.check_provider_readiness",
+           return_value={"status": "ready"})
+    def test_resume_surfaces_recorded_operator_feedback(self, _mock_check) -> None:
         test_root = _fresh_test_root("resume_surfaces_feedback")
         mission_root = test_root / "mission"
         mission_state_path = mission_root / "mission_state.json"

--- a/tests/test_openai_compatible_adapter.py
+++ b/tests/test_openai_compatible_adapter.py
@@ -101,7 +101,10 @@ class OpenAICompatibleAdapterTests(unittest.TestCase):
 
     @patch("deeploop.runtime.openai_compatible_adapter._invoke_openai_compatible")
     def test_main_writes_result_json_from_response(self, mock_invoke) -> None:
-        mock_invoke.return_value = "{\"status\": \"completed\", \"summary\": \"done\"}"
+        mock_invoke.return_value = (
+            "{\"status\": \"completed\", \"summary\": \"done\"}",
+            {"input_tokens": 42, "output_tokens": 17},
+        )
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             prompt_file = root / "prompt.md"
@@ -124,4 +127,6 @@ class OpenAICompatibleAdapterTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["status"], "completed")
         self.assertEqual(payload["summary"], "done")
+        self.assertEqual(payload["tokens"]["input_tokens"], 42)
+        self.assertEqual(payload["tokens"]["output_tokens"], 17)
         self.assertEqual(mock_invoke.call_args.kwargs["json_only"], True)


### PR DESCRIPTION
## Summary

Fixes #114 and 7 additional issues found during code audit.

### #114: Missing API credentials silent failure
- `check_provider_readiness()` now runs unconditionally before daemon launch for ALL start/resume code paths
- Removed duplicate check from auto-bootstrap path

### Critical fixes from audit
- **4a**: `self_healing_runtime.py` now uses atomic `write_mission_state()` instead of direct `write_text()`
- **5a**: Both `openai_compatible_adapter` and `anthropic_adapter` now capture `usage` (input_tokens, output_tokens) from API responses and include them in result JSON

### High fixes
- **5b+5c**: Added Anthropic model pricing (Claude Sonnet/Haiku/Opus/Fable) + deepseek-v4-pro. `accumulate_cost()` warns on unpriced models. Cost model resolved from executor payload instead of hardcoded env var.

### Medium fixes
- **1a**: Removed dead code block after `return` in `recursive_agent_runtime.py`
- **3d**: Added `timeout=300` to triage path in `mission_management.py`

### Test results
```
703 tests, 0 new regressions (6 pre-existing failures)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)